### PR TITLE
Arduino 1.5.8 beta fixup

### DIFF
--- a/dcf77.h
+++ b/dcf77.h
@@ -273,7 +273,7 @@ namespace DCF77_Encoder {
     // to understand the subtle implications.
     void autoset_control_bits(DCF77::time_data_t &now);
 
-    bool verify_leap_second_scheduled(const DCF77::time_data_t &now);
+    bool verify_leap_second_scheduled(const DCF77::time_data_t &now, bool assume_leap_second = false);
 
     void debug(const DCF77::time_data_t &clock);
     void debug(const DCF77::time_data_t &clock, const uint16_t cycles);


### PR DESCRIPTION
Code changes to compile dcf77_library in Arduino Version 1.5.8 Beta (AVR toolchain: gcc 4.8.1, avr-libc 1.8.0).

Code successfully compiled on Windows 7 (x64) and Linux (x64).
Tested on an ATmega328P (Arduino Uno compatible board), got a sync to a DCF-77 signal after several minutes.

About commit 4871693: For some reason the gcc compiler crashed during compiling of the library as long as the "always_inline" attribute was used for the "uint8_t days_per_month()" function.
I don't know too much about the inner workings of the library, but i suspect removing the "always_inline" attribute should not have too much of a negative effect on the decoding. 
