### PR TITLE
Added Leonardo/micro board interrupts

### DIFF
--- a/dcf77.cpp
+++ b/dcf77.cpp
@@ -3223,16 +3223,17 @@ namespace DCF77_1_Khz_Generator {
             // drop one timer step to realign
             OCR2A = 248;
         } else
-            if (cumulated_phase_deviation <= -64000) {
-                // cumulated drift exceeds 1 timer step (4 microseconds)
-                // insert one timer step to realign
-                cumulated_phase_deviation += 64000;
-                OCR2A = 250;
-            } else {
-                // 249 + 1 == 250 == 250 000 / 1000 =  (16 000 000 / 64) / 1000
-                OCR2A = 249;
-            }
-            DCF77_Clock_Controller::process_1_kHz_tick_data(the_input_provider());
+        if (cumulated_phase_deviation <= -64000) {
+            // cumulated drift exceeds 1 timer step (4 microseconds)
+            // insert one timer step to realign
+            cumulated_phase_deviation += 64000;
+            OCR2A = 250;
+        } else {
+            // 249 + 1 == 250 == 250 000 / 1000 =  (16 000 000 / 64) / 1000
+            OCR2A = 249;
+        }
+
+        DCF77_Clock_Controller::process_1_kHz_tick_data(the_input_provider());
     }
 }
 


### PR DESCRIPTION
Existing code was not compiling for Leonardo and micro boards. 

Leonardo and micro boards are ATmega32u4 with different interrupts defined compared to ATmega328 boards (Uno etc.). This pull request will allow code to now compile for ATmega32u4 based boards.