### PR TITLE
Ensure that reverse function is available when running on native hardware

### DIFF
--- a/dcf77.cpp
+++ b/dcf77.cpp
@@ -1636,6 +1636,14 @@ namespace Internal {  // DCF77_Encoder
         data.byte_5 = set_bit(year.val>>3, 5, date_parity);
     }
 #else
+
+    uint8_t reverse(uint8_t b) {
+        b = (b & 0xF0) >> 4 | (b & 0x0F) << 4;
+        b = (b & 0xCC) >> 2 | (b & 0x33) << 2;
+        b = (b & 0xAA) >> 1 | (b & 0x55) << 1;
+        return b;
+    }
+  
     void DCF77_Encoder::get_serialized_clock_stream( DCF77::serialized_clock_stream_pair &data) const {
         using namespace Arithmetic_Tools;
 

--- a/standalone/standalone.cpp
+++ b/standalone/standalone.cpp
@@ -70,10 +70,3 @@ int TIMSK2;
 uint8_t SREG;
 
 DummySerial Serial;
-
-uint8_t reverse(uint8_t b) {
-    b = (b & 0xF0) >> 4 | (b & 0x0F) << 4;
-    b = (b & 0xCC) >> 2 | (b & 0x33) << 2;
-    b = (b & 0xAA) >> 1 | (b & 0x55) << 1;
-    return b;
-}

--- a/standalone/standalone.h
+++ b/standalone/standalone.h
@@ -72,8 +72,6 @@ public:
 
 extern DummySerial Serial;
 
-extern uint8_t reverse(uint8_t b);
-
 #define CRITICAL_SECTION
 
 #endif //DCF77_STANDALONE_H


### PR DESCRIPTION
reverse function was only available when running in Standalone mode.  Moved into main code.

Tested MSF60 today with Arduinio Uno (with 16MHz XTAL) and seems to work OK