### PR TITLE
Added Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+language: cpp
+
+env:
+  global:
+    - ARDUINO_PACKAGE_VERSION=1.8.2
+    - DISPLAY=:1.0
+    - PACKAGE_ID=arduino
+    - ARCH=avr
+
+  matrix:
+    - TARGET_BOARD=uno EXAMPLE=DCF77_Scope
+    - TARGET_BOARD=uno EXAMPLE=MB_Emulator
+    - TARGET_BOARD=uno EXAMPLE=Simple_Clock
+    - TARGET_BOARD=uno EXAMPLE=Simple_Clock_with_Timezone_Support
+    - TARGET_BOARD=uno EXAMPLE=Superfilter
+    - TARGET_BOARD=uno EXAMPLE=Swiss_Army_Debug_Helper
+    - TARGET_BOARD=uno EXAMPLE=The_Clock
+    - TARGET_BOARD=uno EXAMPLE=Time_Switch
+#    - TARGET_BOARD=uno EXAMPLE=Unit_Test
+
+    - TARGET_BOARD=diecimila:cpu=atmega328 EXAMPLE=DCF77_Scope
+    - TARGET_BOARD=diecimila:cpu=atmega328 EXAMPLE=MB_Emulator
+    - TARGET_BOARD=diecimila:cpu=atmega328 EXAMPLE=Simple_Clock
+    - TARGET_BOARD=diecimila:cpu=atmega328 EXAMPLE=Simple_Clock_with_Timezone_Support
+    - TARGET_BOARD=diecimila:cpu=atmega328 EXAMPLE=Superfilter
+    - TARGET_BOARD=diecimila:cpu=atmega328 EXAMPLE=Swiss_Army_Debug_Helper
+    - TARGET_BOARD=diecimila:cpu=atmega328 EXAMPLE=The_Clock
+    - TARGET_BOARD=diecimila:cpu=atmega328 EXAMPLE=Time_Switch
+#    - TARGET_BOARD=diecimila:cpu=atmega328 EXAMPLE=Unit_Test
+
+    - TARGET_BOARD=arduino_due_x ARCH=sam EXAMPLE=DCF77_Scope
+    - TARGET_BOARD=arduino_due_x ARCH=sam EXAMPLE=MB_Emulator
+    - TARGET_BOARD=arduino_due_x ARCH=sam EXAMPLE=Simple_Clock
+    - TARGET_BOARD=arduino_due_x ARCH=sam EXAMPLE=Simple_Clock_with_Timezone_Support
+    - TARGET_BOARD=arduino_due_x ARCH=sam EXAMPLE=Superfilter
+    - TARGET_BOARD=arduino_due_x ARCH=sam EXAMPLE=Swiss_Army_Debug_Helper
+    - TARGET_BOARD=arduino_due_x ARCH=sam EXAMPLE=The_Clock
+    - TARGET_BOARD=arduino_due_x ARCH=sam EXAMPLE=Time_Switch
+    - TARGET_BOARD=arduino_due_x ARCH=sam EXAMPLE=Unit_Test
+
+matrix:
+  allow_failures:
+    - env: TARGET_BOARD=uno EXAMPLE=Unit_Test
+    - env: TARGET_BOARD=diecimila:cpu=atmega328 EXAMPLE=Unit_Test
+
+install:
+  - wget -q -O- http://downloads.arduino.cc/arduino-$ARDUINO_PACKAGE_VERSION-linux64.tar.xz | unxz -c | tar -xf -
+  - mkdir -p ~/Arduino/libraries/
+  - ln -s $TRAVIS_BUILD_DIR ~/Arduino/libraries/
+  - $TRAVIS_BUILD_DIR/arduino-$ARDUINO_PACKAGE_VERSION/arduino --install-boards $PACKAGE_ID:$ARCH
+
+before_script:
+  - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/xvfb_$TRAVIS_JOB_NUMBER.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16
+
+script:
+  - $TRAVIS_BUILD_DIR/arduino-$ARDUINO_PACKAGE_VERSION/arduino --verbose --verify --board $PACKAGE_ID:$ARCH:$TARGET_BOARD $TRAVIS_BUILD_DIR/examples/$EXAMPLE/$EXAMPLE.ino

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # dcf77 library
 
+[![GitHub license](https://img.shields.io/badge/license-AGPL-blue.svg)](https://raw.githubusercontent.com/udoklein/dcf77/master/LICENSE) [![Build Status](https://travis-ci.org/udoklein/dcf77.svg?branch=master)](https://travis-ci.org/udoklein/dcf77)
 
 Noise resilent DCF77 decoder library for Arduino.
 


### PR DESCRIPTION
Hi Udo,

I have added a Travis CI configuration file which automatically tests all example sketches.
For sample results see:
https://travis-ci.org/aido/RadioClock/builds/219827594

I currently have the Unit Test example sketch set to run on a Uno board so it fails on purpose. This was done just for negative testing.
The test matrix is currently set to test on Uno and Duemilanove/Diecimila boards but may be expanded to use other boards such as Leonardo and micro which will be useful for testing your recent commit to the Leonardo branch.

If you wish to merge this PR you will need to log into Travis CI using your github credentials and enable the dcf77 repo.