### PR TITLE
Experimental ESP32 support using espressif arduino-esp32 core

### DIFF
--- a/dcf77.cpp
+++ b/dcf77.cpp
@@ -1879,12 +1879,12 @@ namespace Internal {
 
         #if defined(ARDUINO_ARCH_ESP32)
         hw_timer_t *timer = NULL;
-        const uint32_t GPTimer_freq = 1000000;
+        const uint32_t GPTimer_freq = 16000000;
         const uint32_t ticks_per_ms = GPTimer_freq/1000;
         const uint32_t ticks_per_us = ticks_per_ms/1000;
         
         void setup(const Clock::input_provider_t input_provider) {
-            timer = timerBegin(GPTimer_freq); // Set timer frequency to 1Mhz, 1 us tick
+            timer = timerBegin(GPTimer_freq); // Set timer frequency to 16Mhz, 0,0625 us tick
             timerAttachInterrupt(timer, &isr_handler);
             timerAlarm(timer, ticks_per_ms, true, 0);  // call isr_handler function onetime after 1000 microseconds
             the_input_provider = input_provider;

--- a/dcf77.cpp
+++ b/dcf77.cpp
@@ -1876,6 +1876,21 @@ namespace Internal {
             Clock_Controller::process_1_kHz_tick_data(the_input_provider());
         }
         #endif
+
+        #if defined(ARDUINO_ARCH_ESP32)
+        hw_timer_t *timer = NULL;
+        
+        void setup(const Clock::input_provider_t input_provider) {
+            timer = timerBegin(1000000); // Set timer frequency to 1Mhz, 1 us tick
+            timerAttachInterrupt(timer, &isr_handler);
+            timerAlarm(timer, 1000, true, 0);  // call isr_handler function every 1000 microseconds
+            the_input_provider = input_provider;
+        }
+
+        void ARDUINO_ISR_ATTR isr_handler() {
+            Clock_Controller::process_1_kHz_tick_data(the_input_provider());        
+        }
+        #endif
     }
 }
 

--- a/dcf77.h
+++ b/dcf77.h
@@ -79,8 +79,12 @@ struct Configuration {
 
     // the constant(s) below are assumed to be configured by the user of the library
 
+    #if defined(ARDUINO_ARCH_ESP32)
+    //Low memory footprint default for ESP32
+    static const bool want_high_phase_lock_resolution = false;
+    #else
     static const bool want_high_phase_lock_resolution = true;
-    //const bool want_high_phase_lock_resolution = false;
+    #endif
 
     // end of configuration section, the stuff below
     // will compute the implications of the desired configuration,


### PR DESCRIPTION
Tested using the ESP-WROOM-32 module. 
This module uses a 40 MHz crystal oscillator (+/- 10 ppm). 
The hardware GPTimer is prescaled to tick at 1 MHz, and the 1 kHz generator is triggered by an interrupt every 1000 ticks.